### PR TITLE
Request to fix error if latex is not installed

### DIFF
--- a/evaluate_3d_reconstruction/evaluate_3d_reconstruction.py
+++ b/evaluate_3d_reconstruction/evaluate_3d_reconstruction.py
@@ -108,7 +108,7 @@ def run_evaluation(
     pred_ply_path = path_to_pred_ply + "/" + pred_ply
 
     # output directory
-    out_dir = path_to_pred_ply + "/" + pred_ply[:-4]
+    out_dir = path_to_pred_ply + "/" + "evaluation_results"
 
     # create output directory
     make_dir(out_dir)

--- a/evaluate_3d_reconstruction/evaluation.py
+++ b/evaluate_3d_reconstruction/evaluation.py
@@ -33,6 +33,7 @@
 
 import json
 import copy
+import shutil
 import numpy as np
 import open3d as o3d
 import matplotlib.pyplot as plt
@@ -42,7 +43,7 @@ import matplotlib
 matplotlib.use("Agg")
 
 rc("font", **{"family": "serif", "sans-serif": ["Times New Roman"]})
-rc("text", usetex=True)  # if Latex is installed and executable on PATH
+rc("text", usetex=True if shutil.which('latex') else False)  # if Latex is installed and executable on PATH
 
 
 def write_color_distances_mesh(path, mesh, distances, max_distance):

--- a/evaluate_3d_reconstruction/plot.py
+++ b/evaluate_3d_reconstruction/plot.py
@@ -35,13 +35,13 @@
 # The dataset has a different license, please refer to
 # https://tanksandtemples.org/license/
 
-
+import shutil
 import matplotlib.pyplot as plt
 from cycler import cycler
 from matplotlib import rc
 
 rc("font", **{"family": "serif", "sans-serif": ["Times New Roman"]})
-rc("text", usetex=True)
+rc("text", usetex=True if shutil.which('latex') else False)  # if Latex is installed and executable on PATH
 
 
 def plot_graph(


### PR DESCRIPTION
The pull request changes the following:
- put mesh evaluation results into a separate `evaluation_results` folder, instead of naming the folder by the mesh name
- fix error if latex is not installed on the system